### PR TITLE
Add bash script wrapper to CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-run
+metric_cli
 
 tmpl/index.html
 awesome-go

--- a/cli/commands/build.go
+++ b/cli/commands/build.go
@@ -7,8 +7,9 @@ package commands
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os/exec"
+
+	"github.com/spf13/cobra"
 )
 
 var buildCmd = &cobra.Command{
@@ -20,7 +21,7 @@ var buildCmd = &cobra.Command{
 		app := "go"
 		arg0 := "build"
 		arg1 := "-o"
-		arg2 := "run"
+		arg2 := "metric_cli"
 
 		exec_output := exec.Command(app, arg0, arg1, arg2)
 		stdout, err := exec_output.Output()

--- a/run
+++ b/run
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Not sure if shebang line is needed
+
+# Simple wrapper for Go CLI
+# For commands "install" and "build", use "go run"
+# All other commands, use executable
+    # If there is no executable, return an error
+
+if [ "$1" != "" ] && ([ $1 = "install" ] || [ $1 = "build" ]); then 
+    # If command is "install" or "build", use "go run" to run command
+    go run . $@
+else
+    # Otherwise, require the executable to run the command
+    EXECUTABLE_FILE=metric_cli
+    if [ -f "$EXECUTABLE_FILE" ]; then
+        # Run executable, and foward on all arguments
+        $EXECUTABLE_FILE $@
+    else
+        echo "No executable, compile using './run install' and './run build'"
+    fi
+fi

--- a/run
+++ b/run
@@ -1,5 +1,4 @@
-#!/bin/bash
-# Not sure if shebang line is needed
+#!/usr/bin/env bash
 
 # Simple wrapper for Go CLI
 # For commands "install" and "build", use "go run"


### PR DESCRIPTION
This bash script allows us to use the CLI without requiring the user to manually compile code first. Behind the scenes, it simply compiles the code and runs it